### PR TITLE
[FEATURE] Add Secondary CSV Export With HTML Explanation

### DIFF
--- a/src/Administration/Content.php
+++ b/src/Administration/Content.php
@@ -192,6 +192,19 @@ class GlossaryAdministrationContent extends PapayaAdministrationPagePart {
         );
         $button->caption = new PapayaUiStringTranslated('Export CSV');
         $button->image = 'actions-download';
+        $toolbar->elements[] = $button = new PapayaUiToolbarButton();
+        $button->reference->setParameters(
+          [
+            'mode' => 'terms',
+            'cmd' => 'export',
+            'search-for' => $this->parameters()->get('search-for', ''),
+            'glossary_id' => $this->parameters()->get('glossary_id', 0),
+            'with-html' => 1
+          ],
+          $this->parameterGroup()
+        );
+        $button->caption = new PapayaUiStringTranslated('Export CSV (with HTML)');
+        $button->image = 'actions-download';
       }
       break;
     }

--- a/src/Administration/Content/Term/Export.php
+++ b/src/Administration/Content/Term/Export.php
@@ -21,6 +21,7 @@ class GlossaryAdministrationContentTermExport
       'Content-Disposition',
       'attachment; filename="glossary_export_'.PapayaUtilDate::timestampToString(time(), FALSE, FALSE).'.csv"'
     );
+    $withHTML = $this->parameters()->get('with-html', false);
     $response->content(
       new PapayaResponseContentList(
         new PapayaIteratorCallback(
@@ -28,7 +29,7 @@ class GlossaryAdministrationContentTermExport
             [$columns],
             new PapayaIteratorCallback(
               $this->terms(),
-              function(array $row) use ($columns) {
+              function(array $row) use ($columns, $withHTML) {
                 $result = [];
                 foreach ($columns as $name) {
                   switch ($name) {
@@ -37,7 +38,7 @@ class GlossaryAdministrationContentTermExport
                     $result[$name] = PapayaUtilDate::timestampToString($row[$name], TRUE, TRUE, FALSE);
                     break;
                   case 'explanation' :
-                    $result[$name] = strip_tags($row[$name]);
+                    $result[$name] = $withHTML ? $row[$name] : strip_tags($row[$name]);
                     break;
                   default:
                     $result[$name] = (string)$row[$name];


### PR DESCRIPTION
The secondary CSV export keeps the HTML tags in the explanation field.